### PR TITLE
Pull existing chat groups

### DIFF
--- a/brewchat/src/main/java/com/example/brewchat/ChatService.java
+++ b/brewchat/src/main/java/com/example/brewchat/ChatService.java
@@ -6,6 +6,7 @@ import android.util.Log;
 
 import com.example.brewchat.events.AuthenticationErrorEvent;
 import com.example.brewchat.events.CreateChatError;
+import com.example.brewchat.events.GetGroupChatsErrorEvent;
 import com.example.brewchat.events.GetGroupChatsEvent;
 import com.example.brewchat.events.GroupChatCreatedEvent;
 import com.example.brewchat.events.RegisterUserError;
@@ -183,7 +184,7 @@ public class ChatService implements ConnectionListener,
 
             @Override
             public void onError(List<String> errors) {
-
+                EventBus.getDefault().post(new GetGroupChatsErrorEvent(errors));
             }
         });
     }

--- a/brewchat/src/main/java/com/example/brewchat/ChatService.java
+++ b/brewchat/src/main/java/com/example/brewchat/ChatService.java
@@ -6,6 +6,7 @@ import android.util.Log;
 
 import com.example.brewchat.events.AuthenticationErrorEvent;
 import com.example.brewchat.events.CreateChatError;
+import com.example.brewchat.events.GetGroupChatsEvent;
 import com.example.brewchat.events.GroupChatCreatedEvent;
 import com.example.brewchat.events.RegisterUserError;
 import com.example.brewchat.events.UserLoggedEvent;
@@ -33,6 +34,7 @@ import com.quickblox.chat.model.QBPresence;
 import com.quickblox.chat.model.QBPrivacyListItem;
 import com.quickblox.core.QBEntityCallbackImpl;
 import com.quickblox.core.QBSettings;
+import com.quickblox.core.request.QBRequestGetBuilder;
 import com.quickblox.users.QBUsers;
 import com.quickblox.users.model.QBUser;
 
@@ -115,7 +117,7 @@ public class ChatService implements ConnectionListener,
         });
 
 
-            }
+    }
 
     public void logout() {
         try {
@@ -125,7 +127,7 @@ public class ChatService implements ConnectionListener,
         }
     }
 
-    public void addChatGroup(String name, ArrayList<Integer> userIds){
+    public void addChatGroup(String name, ArrayList<Integer> userIds) {
         QBDialog dialog = new QBDialog();
         dialog.setName(name);
         dialog.setType(QBDialogType.GROUP);
@@ -135,7 +137,7 @@ public class ChatService implements ConnectionListener,
         groupChatManager.createDialog(dialog, new QBEntityCallbackImpl<QBDialog>() {
             @Override
             public void onSuccess(QBDialog dialog, Bundle args) {
-                GroupChatCreatedEvent groupChatCreatedEvent = new GroupChatCreatedEvent(dialog.getName(), dialog.getOccupants());
+                GroupChatCreatedEvent groupChatCreatedEvent = new GroupChatCreatedEvent(dialog);
                 EventBus.getDefault().post(groupChatCreatedEvent);
                 Log.d(TAG, "Created new Group Chat");
             }
@@ -167,6 +169,23 @@ public class ChatService implements ConnectionListener,
             }
         });
 
+    }
+
+    public void getChatDialogs() {
+        QBRequestGetBuilder requestGetBuilder = new QBRequestGetBuilder();
+        requestGetBuilder.setPagesLimit(100);
+
+        QBChatService.getChatDialogs(null, requestGetBuilder, new QBEntityCallbackImpl<ArrayList<QBDialog>>() {
+            @Override
+            public void onSuccess(ArrayList<QBDialog> dialogs, Bundle args) {
+                EventBus.getDefault().post(new GetGroupChatsEvent(dialogs));
+            }
+
+            @Override
+            public void onError(List<String> errors) {
+
+            }
+        });
     }
 
     // ConnectionListener

--- a/brewchat/src/main/java/com/example/brewchat/activities/ChatManagerActivity.java
+++ b/brewchat/src/main/java/com/example/brewchat/activities/ChatManagerActivity.java
@@ -13,10 +13,12 @@ import com.example.brewchat.Application;
 import com.example.brewchat.R;
 import com.example.brewchat.domain.ChatGroup;
 import com.example.brewchat.events.CreateChatError;
+import com.example.brewchat.events.GetGroupChatsEvent;
 import com.example.brewchat.events.GroupChatCreatedEvent;
 import com.example.brewchat.fragments.ChatManagerFragment;
 import com.example.brewchat.fragments.CreateChatDialogFragment;
 import com.example.brewchat.interfaces.AddChatGroupListener;
+import com.quickblox.chat.model.QBDialog;
 
 import java.util.ArrayList;
 
@@ -37,6 +39,7 @@ public class ChatManagerActivity extends AppCompatActivity implements AddChatGro
                     .add(R.id.chat_manager_container, chatManagerFragment)
                     .commit();
         }
+        ((Application)getApplication()).getChatService().getChatDialogs();
 
     }
 
@@ -55,12 +58,16 @@ public class ChatManagerActivity extends AppCompatActivity implements AddChatGro
     @SuppressWarnings("unused")
     public void onEvent(GroupChatCreatedEvent event) {
         Toast.makeText(this,getString(R.string.chat_created_toast),Toast.LENGTH_LONG).show();
-        chatManagerFragment.addChatGroup(new ChatGroup(event.getName(), event.getUserIds()));
+        chatManagerFragment.addChatGroup(event.getDialog());
     }
 
     public void onEvent(CreateChatError event) {
         //TODO make more informative error message
         Toast.makeText(this,getString(R.string.create_chat_error_toast), Toast.LENGTH_LONG).show();
+    }
+
+    public void onEvent(GetGroupChatsEvent event) {
+        chatManagerFragment.setChatGroupList(event.getChatGroups());
     }
 
     public void addChatGroup(String title, ArrayList<Integer> userIds) {

--- a/brewchat/src/main/java/com/example/brewchat/activities/ChatManagerActivity.java
+++ b/brewchat/src/main/java/com/example/brewchat/activities/ChatManagerActivity.java
@@ -13,6 +13,7 @@ import com.example.brewchat.Application;
 import com.example.brewchat.R;
 import com.example.brewchat.domain.ChatGroup;
 import com.example.brewchat.events.CreateChatError;
+import com.example.brewchat.events.GetGroupChatsErrorEvent;
 import com.example.brewchat.events.GetGroupChatsEvent;
 import com.example.brewchat.events.GroupChatCreatedEvent;
 import com.example.brewchat.fragments.ChatManagerFragment;
@@ -68,6 +69,13 @@ public class ChatManagerActivity extends AppCompatActivity implements AddChatGro
 
     public void onEvent(GetGroupChatsEvent event) {
         chatManagerFragment.setChatGroupList(event.getChatGroups());
+    }
+
+    public void onEvent(GetGroupChatsErrorEvent event) {
+        Toast.makeText(this, "Error pulling chats groups from server", Toast.LENGTH_LONG).show();
+        for(String error: event.getErrors()){
+            Log.e("ChatManagerActivity", error);
+        }
     }
 
     public void addChatGroup(String title, ArrayList<Integer> userIds) {

--- a/brewchat/src/main/java/com/example/brewchat/adapters/ChatGroupRecyclerAdapter.java
+++ b/brewchat/src/main/java/com/example/brewchat/adapters/ChatGroupRecyclerAdapter.java
@@ -11,6 +11,7 @@ import android.widget.TextView;
 import com.example.brewchat.R;
 import com.example.brewchat.activities.GroupChatActivity;
 import com.example.brewchat.domain.ChatGroup;
+import com.quickblox.chat.model.QBDialog;
 
 import java.util.ArrayList;
 
@@ -23,12 +24,11 @@ public class ChatGroupRecyclerAdapter extends RecyclerView.Adapter<ChatGroupRecy
 
     Context context;
     LayoutInflater inflater;
-    ArrayList<ChatGroup> chatGroups = new ArrayList<ChatGroup>();
+    ArrayList<QBDialog> chatGroups = new ArrayList<>();
 
     public ChatGroupRecyclerAdapter(Context context) {
         this.context = context;
         inflater = LayoutInflater.from(context);
-        this.chatGroups = chatGroups;
     }
 
     @Override
@@ -39,14 +39,18 @@ public class ChatGroupRecyclerAdapter extends RecyclerView.Adapter<ChatGroupRecy
 
     @Override
     public void onBindViewHolder(ChatGroupRecyclerAdapter.MyViewHolder holder, int position) {
-        ChatGroup currentChatGroup = chatGroups.get(position);
-        holder.title.setText(currentChatGroup.getTitle());
-        holder.description.setText(currentChatGroup.getChatInfo());
+        QBDialog currentChatGroup = chatGroups.get(position);
+        holder.title.setText(currentChatGroup.getName());
+//        holder.description.setText(currentChatGroup.);
         holder.itemView.setOnClickListener(new JoinChatClickListener(position));
     }
 
-    public void addChatGroup(ChatGroup chatGroup){
+    public void addChatGroup(QBDialog chatGroup){
         chatGroups.add(chatGroup);
+    }
+
+    public void setChatGroupList(ArrayList<QBDialog> chatGroupList){
+        chatGroups.addAll(chatGroupList);
     }
 
     @Override

--- a/brewchat/src/main/java/com/example/brewchat/events/GetGroupChatsErrorEvent.java
+++ b/brewchat/src/main/java/com/example/brewchat/events/GetGroupChatsErrorEvent.java
@@ -1,0 +1,22 @@
+package com.example.brewchat.events;
+
+import java.util.List;
+
+/**
+ * Event for errors in pulling group chat list from QB
+ *
+ * Created by josh on 4/28/15.
+ */
+public class GetGroupChatsErrorEvent {
+
+    List<String> errors;
+
+    public GetGroupChatsErrorEvent(List<String> errors) {
+        this.errors = errors;
+    }
+
+    public List<String> getErrors() {
+        return errors;
+    }
+
+}

--- a/brewchat/src/main/java/com/example/brewchat/events/GetGroupChatsEvent.java
+++ b/brewchat/src/main/java/com/example/brewchat/events/GetGroupChatsEvent.java
@@ -1,0 +1,22 @@
+package com.example.brewchat.events;
+
+import com.quickblox.chat.model.QBDialog;
+
+import java.util.ArrayList;
+
+/**
+ * Event for populating the chat manager chat groups list
+ *
+ * Created by josh on 4/28/15.
+ */
+public class GetGroupChatsEvent {
+    private ArrayList<QBDialog> chatGroups;
+
+    public ArrayList<QBDialog> getChatGroups() {
+        return chatGroups;
+    }
+
+    public GetGroupChatsEvent(ArrayList<QBDialog> chatGroups) {
+        this.chatGroups = chatGroups;
+    }
+}

--- a/brewchat/src/main/java/com/example/brewchat/events/GroupChatCreatedEvent.java
+++ b/brewchat/src/main/java/com/example/brewchat/events/GroupChatCreatedEvent.java
@@ -1,25 +1,24 @@
 package com.example.brewchat.events;
 
+import com.quickblox.chat.model.QBDialog;
+
 import java.util.ArrayList;
 
 /**
+ * Event for notifying creation of new QB chat group
+ *
  * Created by Ryan on 4/25/2015.
  */
 public class GroupChatCreatedEvent{
-    private String name;
-    private ArrayList<Integer> userIds;
 
-    public GroupChatCreatedEvent(String name, ArrayList<Integer> ids){
-        this.name = name;
-        this.userIds = userIds;
+    private QBDialog dialog;
 
+    public GroupChatCreatedEvent(QBDialog dialog){
+        this.dialog = dialog;
     }
 
-    public ArrayList<Integer> getUserIds() {
-        return userIds;
+    public QBDialog getDialog() {
+        return dialog;
     }
 
-    public String getName() {
-        return name;
-    }
 }

--- a/brewchat/src/main/java/com/example/brewchat/fragments/ChatManagerFragment.java
+++ b/brewchat/src/main/java/com/example/brewchat/fragments/ChatManagerFragment.java
@@ -11,6 +11,9 @@ import android.view.ViewGroup;
 import com.example.brewchat.R;
 import com.example.brewchat.adapters.ChatGroupRecyclerAdapter;
 import com.example.brewchat.domain.ChatGroup;
+import com.quickblox.chat.model.QBDialog;
+
+import java.util.ArrayList;
 
 /**
  * Created by Josh
@@ -47,8 +50,13 @@ public class ChatManagerFragment extends Fragment{
 
         return layout;
     }
-    public void addChatGroup(ChatGroup chatGroup){
+    public void addChatGroup(QBDialog chatGroup){
         adapter.addChatGroup(chatGroup);
+        adapter.notifyDataSetChanged();
+    }
+
+    public void setChatGroupList(ArrayList<QBDialog> chatGroupList) {
+        adapter.setChatGroupList(chatGroupList);
         adapter.notifyDataSetChanged();
     }
 

--- a/brewchat/src/main/java/com/example/brewchat/fragments/ChatManagerFragment.java
+++ b/brewchat/src/main/java/com/example/brewchat/fragments/ChatManagerFragment.java
@@ -49,6 +49,7 @@ public class ChatManagerFragment extends Fragment{
     }
     public void addChatGroup(ChatGroup chatGroup){
         adapter.addChatGroup(chatGroup);
+        adapter.notifyDataSetChanged();
     }
 
 

--- a/brewchat/src/main/java/com/example/brewchat/fragments/CreateChatDialogFragment.java
+++ b/brewchat/src/main/java/com/example/brewchat/fragments/CreateChatDialogFragment.java
@@ -63,6 +63,10 @@ public class CreateChatDialogFragment extends DialogFragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.create_chat_dialog,container,false);
         ButterKnife.inject(this, view);
+
+        // for testing purposes - saves typing
+        editTextChatName.setText("Test group chat");
+        editTextAddUsers.setText("2965508,2965510,2965514");
         return view;
     }
 

--- a/brewchat/src/main/java/com/example/brewchat/fragments/CreateChatDialogFragment.java
+++ b/brewchat/src/main/java/com/example/brewchat/fragments/CreateChatDialogFragment.java
@@ -23,6 +23,8 @@ import butterknife.InjectView;
 import butterknife.OnClick;
 
 /**
+ * Dialog for constructing new QB chat group
+ *
  * Created by josh on 4/26/15.
  */
 public class CreateChatDialogFragment extends DialogFragment {
@@ -76,6 +78,7 @@ public class CreateChatDialogFragment extends DialogFragment {
         ArrayList<String> userStringIds = getUserStringIds();
         ArrayList<Integer> userIds = getUserIds(userStringIds);
         addChatGroupListener.addChatGroup(editTextChatName.getText().toString(), userIds);
+        dismiss();
     }
 
     @OnClick(R.id.create_chat_cancel_button)

--- a/brewchat/src/main/java/com/example/brewchat/fragments/LoginFragment.java
+++ b/brewchat/src/main/java/com/example/brewchat/fragments/LoginFragment.java
@@ -62,6 +62,11 @@ public class LoginFragment extends Fragment {
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.login_fragment, container, false);
         ButterKnife.inject(this, view);
+
+        // for testing, set default values to save typing
+        usernameEditText.setText("user1");
+        passwordEditText.setText("12345678");
+        
         return view;
     }
 

--- a/brewchat/src/main/java/com/example/brewchat/fragments/LoginFragment.java
+++ b/brewchat/src/main/java/com/example/brewchat/fragments/LoginFragment.java
@@ -66,7 +66,7 @@ public class LoginFragment extends Fragment {
         // for testing, set default values to save typing
         usernameEditText.setText("user1");
         passwordEditText.setText("12345678");
-        
+
         return view;
     }
 

--- a/brewchat/src/main/res/values/config.xml
+++ b/brewchat/src/main/res/values/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_id">22306</string>
-    <string name="auth_key">S2pgg2kV3cfLUAm</string>
-    <string name="auth_secret">am-HzubL-aMmekY</string>
+    <string name="app_id">22356</string>
+    <string name="auth_key">794ABqjXu4p7WBS</string>
+    <string name="auth_secret">TRjjNbP-3zpYwDD</string>
 </resources>


### PR DESCRIPTION
Added method in ChatService to pull list of chat groups from QB server (they call them dialogs)
Added events for transporting list to activities
Sends List of chat groups to fragments for display

-Fixed some minor issues with adapter being updated on ChatManagerFragment
-Added dismiss() to the create group dialog fragment (the dialog would stay on the screen before) 
